### PR TITLE
fix(query-core): ensure onMutate runs synchronously when cache config is undefined (#8724)

### DIFF
--- a/.changeset/giant-apples-wear.md
+++ b/.changeset/giant-apples-wear.md
@@ -1,0 +1,5 @@
+---
+'@tanstack/query-core': patch
+---
+
+Fix: onMutate callback now runs synchronously when mutationCache.config.onMutate is not defined

--- a/packages/query-core/src/__tests__/mutationCache.test.tsx
+++ b/packages/query-core/src/__tests__/mutationCache.test.tsx
@@ -249,6 +249,30 @@ describe('mutationCache', () => {
 
       expect(states).toEqual([1, 2, 3, 4])
     })
+
+    test('options.onMutate should run synchronously when mutationCache.config.onMutate is not defined', () => {
+      const key = queryKey()
+      const states: Array<string> = []
+
+      // No onMutate in cache config
+      const testCache = new MutationCache({})
+      const testClient = new QueryClient({ mutationCache: testCache })
+
+      executeMutation(
+        testClient,
+        {
+          mutationKey: key,
+          mutationFn: () => sleep(10).then(() => ({ data: 5 })),
+          onMutate: () => {
+            states.push('onMutate')
+            return 'context'
+          },
+        },
+        'vars',
+      )
+
+      expect(states).toEqual(['onMutate'])
+    })
   })
 
   describe('find', () => {

--- a/packages/query-core/src/mutation.ts
+++ b/packages/query-core/src/mutation.ts
@@ -212,11 +212,13 @@ export class Mutation<
       } else {
         this.#dispatch({ type: 'pending', variables, isPaused })
         // Notify cache callback
-        await this.#mutationCache.config.onMutate?.(
-          variables,
-          this as Mutation<unknown, unknown, unknown, unknown>,
-          mutationFnContext,
-        )
+        if (this.#mutationCache.config.onMutate) {
+          await this.#mutationCache.config.onMutate(
+            variables,
+            this as Mutation<unknown, unknown, unknown, unknown>,
+            mutationFnContext,
+          )
+        }
         const context = await this.options.onMutate?.(
           variables,
           mutationFnContext,


### PR DESCRIPTION
## 🎯 Changes

Previously, `mutationCache.config.onMutate` was always awaited using optional chaining (`await this.#mutationCache.config.onMutate?.()`), which caused unnecessary async behavior even when the callback was undefined.

- Changed to conditional check: only await when `onMutate` is actually defined
- Added regression test to verify synchronous execution when cache config is not provided


## ✅ Checklist

- [x] I have followed the steps in the [Contributing guide](https://github.com/TanStack/query/blob/main/CONTRIBUTING.md).
- [x] I have tested this code locally with `pnpm run test:pr`.

## 🚀 Release Impact

- [x] This change affects published code, and I have generated a [changeset](https://github.com/changesets/changesets/blob/main/docs/adding-a-changeset.md).
- [x] This change is docs/CI/dev-only (no release).
